### PR TITLE
WEBDEV-7259 Make metadata immutable and non-optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/iaux-item-metadata",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/iaux-item-metadata",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -100,7 +100,7 @@ export class File {
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  constructor(json: Record<string, any>) {
+  constructor(json: Record<string, any> = {}) {
     this.rawValue = json;
   }
 }

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -15,7 +15,7 @@ import {
  */
 export class File {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  rawValue: Record<string, any>;
+  readonly rawValue: Readonly<Record<string, any>>;
 
   get name(): string {
     return this.rawValue.name;

--- a/src/models/metadata-fields/metadata-field.ts
+++ b/src/models/metadata-fields/metadata-field.ts
@@ -22,7 +22,7 @@ export interface MetadataFieldInterface<T> {
    * @type {MetadataRawValue}
    * @memberof MetadataField
    */
-  readonly rawValue?: Readonly<MetadataRawValue>;
+  readonly rawValue: Readonly<MetadataRawValue>;
 
   /**
    * The first value if there are multiple or the only value if there is one
@@ -75,7 +75,7 @@ export class MetadataField<
 > implements MetadataFieldInterface<Type>
 {
   /** @inheritdoc */
-  readonly rawValue?: Readonly<MetadataRawValue>;
+  readonly rawValue: Readonly<MetadataRawValue>;
 
   /** @inheritdoc */
   @Memoize() get values(): Type[] {
@@ -88,7 +88,7 @@ export class MetadataField<
     return this.values[0];
   }
 
-  constructor(parser: FieldParserInterfaceType, rawValue?: MetadataRawValue) {
+  constructor(parser: FieldParserInterfaceType, rawValue: MetadataRawValue) {
     this.parser = parser;
     this.rawValue = rawValue;
   }
@@ -96,8 +96,6 @@ export class MetadataField<
   private parser: FieldParserInterfaceType;
 
   private parseRawValue(): Type[] {
-    if (this.rawValue === undefined) return [];
-
     const rawValues = Array.isArray(this.rawValue)
       ? this.rawValue
       : [this.rawValue];

--- a/src/models/metadata-fields/metadata-field.ts
+++ b/src/models/metadata-fields/metadata-field.ts
@@ -22,7 +22,7 @@ export interface MetadataFieldInterface<T> {
    * @type {MetadataRawValue}
    * @memberof MetadataField
    */
-  rawValue?: MetadataRawValue;
+  readonly rawValue?: Readonly<MetadataRawValue>;
 
   /**
    * The first value if there are multiple or the only value if there is one
@@ -75,7 +75,7 @@ export class MetadataField<
 > implements MetadataFieldInterface<Type>
 {
   /** @inheritdoc */
-  rawValue?: MetadataRawValue;
+  readonly rawValue?: Readonly<MetadataRawValue>;
 
   /** @inheritdoc */
   @Memoize() get values(): Type[] {

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -27,7 +27,7 @@ export class Metadata {
    * @memberof Metadata
    */
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  rawMetadata?: Record<string, any>;
+  readonly rawMetadata: Readonly<Record<string, any>>;
 
   /**
    * The item identifier.
@@ -39,29 +39,29 @@ export class Metadata {
    * @memberof Metadata
    */
   get identifier(): string | undefined {
-    return this.rawMetadata?.identifier;
+    return this.rawMetadata.identifier;
   }
 
   @Memoize() get addeddate(): DateField | undefined {
-    return this.rawMetadata?.addeddate
+    return this.rawMetadata.addeddate
       ? new DateField(this.rawMetadata.addeddate)
       : undefined;
   }
 
   @Memoize() get audio_codec(): StringField | undefined {
-    return this.rawMetadata?.audio_codec
+    return this.rawMetadata.audio_codec
       ? new StringField(this.rawMetadata.audio_codec)
       : undefined;
   }
 
   @Memoize() get audio_sample_rate(): NumberField | undefined {
-    return this.rawMetadata?.audio_sample_rate
+    return this.rawMetadata.audio_sample_rate
       ? new NumberField(this.rawMetadata.audio_sample_rate)
       : undefined;
   }
 
   @Memoize() get avg_rating(): NumberField | undefined {
-    return this.rawMetadata?.avg_rating
+    return this.rawMetadata.avg_rating
       ? new NumberField(this.rawMetadata.avg_rating)
       : undefined;
   }
@@ -75,7 +75,7 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get collection(): StringField | undefined {
-    return this.rawMetadata?.collection
+    return this.rawMetadata.collection
       ? new StringField(this.rawMetadata.collection)
       : undefined;
   }
@@ -92,7 +92,7 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get collections_raw(): StringField | undefined {
-    return this.rawMetadata?.collections_raw
+    return this.rawMetadata.collections_raw
       ? new StringField(this.rawMetadata.collections_raw)
       : undefined;
   }
@@ -104,43 +104,43 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get collection_size(): ByteField | undefined {
-    return this.rawMetadata?.collection_size
+    return this.rawMetadata.collection_size
       ? new ByteField(this.rawMetadata.collection_size)
       : undefined;
   }
 
   @Memoize() get contributor(): StringField | undefined {
-    return this.rawMetadata?.contributor
+    return this.rawMetadata.contributor
       ? new StringField(this.rawMetadata.contributor)
       : undefined;
   }
 
   @Memoize() get coverage(): StringField | undefined {
-    return this.rawMetadata?.coverage
+    return this.rawMetadata.coverage
       ? new StringField(this.rawMetadata.coverage)
       : undefined;
   }
 
   @Memoize() get creator(): StringField | undefined {
-    return this.rawMetadata?.creator
+    return this.rawMetadata.creator
       ? new StringField(this.rawMetadata.creator)
       : undefined;
   }
 
   @Memoize() get collection_layout(): StringField | undefined {
-    return this.rawMetadata?.collection_layout
+    return this.rawMetadata.collection_layout
       ? new StringField(this.rawMetadata.collection_layout)
       : undefined;
   }
 
   @Memoize() get date(): DateField | undefined {
-    return this.rawMetadata?.date
+    return this.rawMetadata.date
       ? new DateField(this.rawMetadata.date)
       : undefined;
   }
 
   @Memoize() get description(): StringField | undefined {
-    return this.rawMetadata?.description
+    return this.rawMetadata.description
       ? new StringField(this.rawMetadata.description)
       : undefined;
   }
@@ -152,7 +152,7 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get downloads(): NumberField | undefined {
-    return this.rawMetadata?.downloads
+    return this.rawMetadata.downloads
       ? new NumberField(this.rawMetadata.downloads)
       : undefined;
   }
@@ -164,14 +164,14 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get duration(): DurationField | undefined {
-    return this.rawMetadata?.duration
+    return this.rawMetadata.duration
       ? new DurationField(this.rawMetadata.duration)
       : undefined;
   }
 
   @Memoize() get external_identifier(): StringField | undefined {
-    return this.rawMetadata?.['external-identifier']
-      ? new StringField(this.rawMetadata?.['external-identifier'])
+    return this.rawMetadata['external-identifier']
+      ? new StringField(this.rawMetadata['external-identifier'])
       : undefined;
   }
 
@@ -182,25 +182,25 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get files_count(): NumberField | undefined {
-    return this.rawMetadata?.files_count
+    return this.rawMetadata.files_count
       ? new NumberField(this.rawMetadata.files_count)
       : undefined;
   }
 
   @Memoize() get indexdate(): DateField | undefined {
-    return this.rawMetadata?.indexdate
+    return this.rawMetadata.indexdate
       ? new DateField(this.rawMetadata.indexdate)
       : undefined;
   }
 
   @Memoize() get isbn(): StringField | undefined {
-    return this.rawMetadata?.isbn
+    return this.rawMetadata.isbn
       ? new StringField(this.rawMetadata.isbn)
       : undefined;
   }
 
   @Memoize() get issue(): StringField | undefined {
-    return this.rawMetadata?.issue
+    return this.rawMetadata.issue
       ? new StringField(this.rawMetadata.issue)
       : undefined;
   }
@@ -212,7 +212,7 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get item_count(): NumberField | undefined {
-    return this.rawMetadata?.item_count
+    return this.rawMetadata.item_count
       ? new NumberField(this.rawMetadata.item_count)
       : undefined;
   }
@@ -224,25 +224,25 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get item_size(): ByteField | undefined {
-    return this.rawMetadata?.item_size
+    return this.rawMetadata.item_size
       ? new ByteField(this.rawMetadata.item_size)
       : undefined;
   }
 
   @Memoize() get language(): StringField | undefined {
-    return this.rawMetadata?.language
+    return this.rawMetadata.language
       ? new StringField(this.rawMetadata.language)
       : undefined;
   }
 
   @Memoize() get length(): DurationField | undefined {
-    return this.rawMetadata?.length
+    return this.rawMetadata.length
       ? new DurationField(this.rawMetadata.length)
       : undefined;
   }
 
   @Memoize() get lineage(): StringField | undefined {
-    return this.rawMetadata?.lineage
+    return this.rawMetadata.lineage
       ? new StringField(this.rawMetadata.lineage)
       : undefined;
   }
@@ -254,25 +254,25 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get month(): NumberField | undefined {
-    return this.rawMetadata?.month
+    return this.rawMetadata.month
       ? new NumberField(this.rawMetadata.month)
       : undefined;
   }
 
   @Memoize() get mediatype(): MediaTypeField | undefined {
-    return this.rawMetadata?.mediatype
+    return this.rawMetadata.mediatype
       ? new MediaTypeField(this.rawMetadata.mediatype)
       : undefined;
   }
 
   @Memoize() get noindex(): BooleanField | undefined {
-    return this.rawMetadata?.noindex
+    return this.rawMetadata.noindex
       ? new BooleanField(this.rawMetadata.noindex)
       : undefined;
   }
 
   @Memoize() get notes(): StringField | undefined {
-    return this.rawMetadata?.notes
+    return this.rawMetadata.notes
       ? new StringField(this.rawMetadata.notes)
       : undefined;
   }
@@ -284,157 +284,157 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get num_favorites(): NumberField | undefined {
-    return this.rawMetadata?.num_favorites
+    return this.rawMetadata.num_favorites
       ? new NumberField(this.rawMetadata.num_favorites)
       : undefined;
   }
 
   @Memoize() get num_reviews(): NumberField | undefined {
-    return this.rawMetadata?.num_reviews
+    return this.rawMetadata.num_reviews
       ? new NumberField(this.rawMetadata.num_reviews)
       : undefined;
   }
 
   @Memoize() get openlibrary_edition(): StringField | undefined {
-    return this.rawMetadata?.openlibrary_edition
+    return this.rawMetadata.openlibrary_edition
       ? new StringField(this.rawMetadata.openlibrary_edition)
       : undefined;
   }
 
   @Memoize() get openlibrary_work(): StringField | undefined {
-    return this.rawMetadata?.openlibrary_work
+    return this.rawMetadata.openlibrary_work
       ? new StringField(this.rawMetadata.openlibrary_work)
       : undefined;
   }
 
   @Memoize() get page_progression(): PageProgressionField | undefined {
-    return this.rawMetadata?.page_progression
+    return this.rawMetadata.page_progression
       ? new PageProgressionField(this.rawMetadata.page_progression)
       : undefined;
   }
 
   @Memoize() get partner(): StringField | undefined {
-    return this.rawMetadata?.partner
+    return this.rawMetadata.partner
       ? new StringField(this.rawMetadata.partner)
       : undefined;
   }
 
   @Memoize() get ppi(): NumberField | undefined {
-    return this.rawMetadata?.ppi
+    return this.rawMetadata.ppi
       ? new NumberField(this.rawMetadata.ppi)
       : undefined;
   }
 
   @Memoize() get publicdate(): DateField | undefined {
-    return this.rawMetadata?.publicdate
+    return this.rawMetadata.publicdate
       ? new DateField(this.rawMetadata.publicdate)
       : undefined;
   }
 
   @Memoize() get publisher(): StringField | undefined {
-    return this.rawMetadata?.publisher
+    return this.rawMetadata.publisher
       ? new StringField(this.rawMetadata.publisher)
       : undefined;
   }
 
   @Memoize() get reviewdate(): DateField | undefined {
-    return this.rawMetadata?.reviewdate
+    return this.rawMetadata.reviewdate
       ? new DateField(this.rawMetadata.reviewdate)
       : undefined;
   }
 
   @Memoize() get runtime(): DurationField | undefined {
-    return this.rawMetadata?.runtime
+    return this.rawMetadata.runtime
       ? new DurationField(this.rawMetadata.runtime)
       : undefined;
   }
 
   @Memoize() get scanner(): StringField | undefined {
-    return this.rawMetadata?.scanner
+    return this.rawMetadata.scanner
       ? new StringField(this.rawMetadata.scanner)
       : undefined;
   }
 
   @Memoize() get source(): StringField | undefined {
-    return this.rawMetadata?.source
+    return this.rawMetadata.source
       ? new StringField(this.rawMetadata.source)
       : undefined;
   }
 
   @Memoize() get start_localtime(): DateField | undefined {
-    return this.rawMetadata?.start_localtime
+    return this.rawMetadata.start_localtime
       ? new DateField(this.rawMetadata.start_localtime)
       : undefined;
   }
 
   @Memoize() get start_time(): DateField | undefined {
-    return this.rawMetadata?.start_time
+    return this.rawMetadata.start_time
       ? new DateField(this.rawMetadata.start_time)
       : undefined;
   }
 
   @Memoize() get stop_time(): DateField | undefined {
-    return this.rawMetadata?.stop_time
+    return this.rawMetadata.stop_time
       ? new DateField(this.rawMetadata.stop_time)
       : undefined;
   }
 
   @Memoize() get subject(): StringListField | undefined {
-    return this.rawMetadata?.subject
+    return this.rawMetadata.subject
       ? new StringListField(this.rawMetadata.subject)
       : undefined;
   }
 
   @Memoize() get taper(): StringField | undefined {
-    return this.rawMetadata?.taper
+    return this.rawMetadata.taper
       ? new StringField(this.rawMetadata.taper)
       : undefined;
   }
 
   @Memoize() get title(): StringField | undefined {
-    return this.rawMetadata?.title
+    return this.rawMetadata.title
       ? new StringField(this.rawMetadata.title)
       : undefined;
   }
 
   @Memoize() get transferer(): StringField | undefined {
-    return this.rawMetadata?.transferer
+    return this.rawMetadata.transferer
       ? new StringField(this.rawMetadata.transferer)
       : undefined;
   }
 
   @Memoize() get track(): NumberField | undefined {
-    return this.rawMetadata?.track
+    return this.rawMetadata.track
       ? new NumberField(this.rawMetadata.track)
       : undefined;
   }
 
   @Memoize() get type(): StringField | undefined {
-    return this.rawMetadata?.type
+    return this.rawMetadata.type
       ? new StringField(this.rawMetadata.type)
       : undefined;
   }
 
   @Memoize() get uploader(): StringField | undefined {
-    return this.rawMetadata?.uploader
+    return this.rawMetadata.uploader
       ? new StringField(this.rawMetadata.uploader)
       : undefined;
   }
 
   @Memoize() get utc_offset(): NumberField | undefined {
-    return this.rawMetadata?.utc_offset
+    return this.rawMetadata.utc_offset
       ? new NumberField(this.rawMetadata.utc_offset)
       : undefined;
   }
 
   @Memoize() get venue(): StringField | undefined {
-    return this.rawMetadata?.venue
+    return this.rawMetadata.venue
       ? new StringField(this.rawMetadata.venue)
       : undefined;
   }
 
   @Memoize() get volume(): StringField | undefined {
-    return this.rawMetadata?.volume
+    return this.rawMetadata.volume
       ? new StringField(this.rawMetadata.volume)
       : undefined;
   }
@@ -446,19 +446,19 @@ export class Metadata {
    * @memberof Metadata
    */
   @Memoize() get week(): NumberField | undefined {
-    return this.rawMetadata?.week
+    return this.rawMetadata.week
       ? new NumberField(this.rawMetadata.week)
       : undefined;
   }
 
   @Memoize() get year(): DateField | undefined {
-    return this.rawMetadata?.year
+    return this.rawMetadata.year
       ? new DateField(this.rawMetadata.year)
       : undefined;
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  constructor(json: Record<string, any>) {
+  constructor(json: Record<string, any> = {}) {
     this.rawMetadata = json;
   }
 }

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -36,7 +36,7 @@ export class Review {
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  constructor(json: Record<string, any>) {
+  constructor(json: Record<string, any> = {}) {
     this.rawValue = json;
   }
 }

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -3,7 +3,7 @@ import { DateParser, NumberParser } from '@internetarchive/field-parsers';
 
 export class Review {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  rawValue: Record<string, any>;
+  readonly rawValue: Readonly<Record<string, any>>;
 
   get reviewbody(): string | undefined {
     return this.rawValue.reviewbody;

--- a/src/models/speech-music-asr-entry.ts
+++ b/src/models/speech-music-asr-entry.ts
@@ -2,9 +2,9 @@
  * This is the format used for radio transcripts
  */
 export type SpeechMusicASREntry = {
-  end: number;
-  id: number;
-  is_music: boolean;
-  start: number;
-  text: string;
+  readonly end: number;
+  readonly id: number;
+  readonly is_music: boolean;
+  readonly start: number;
+  readonly text: string;
 };

--- a/test/models/metadata-fields/metadata-field.test.ts
+++ b/test/models/metadata-fields/metadata-field.test.ts
@@ -67,37 +67,6 @@ describe('Metadata Field', () => {
     expect(metadataField.values).to.deep.equal([1.3, 2.4, 4.5]);
   });
 
-  it('has no value if a raw value was not passed in', () => {
-    class MockFloatParser implements FieldParserInterface<number> {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      parseValue(rawValue: any): number {
-        return rawValue;
-      }
-    }
-
-    const parser = new MockFloatParser();
-    const metadataField = new MetadataField(parser);
-
-    expect(metadataField.rawValue).to.equal(undefined);
-    expect(metadataField.value).to.equal(undefined);
-    expect(metadataField.values).to.deep.equal([]);
-  });
-
-  it('does not add value to values array if parsed value is undefined', () => {
-    class MockFloatParser implements FieldParserInterface<number> {
-      parseValue(): number | undefined {
-        return undefined;
-      }
-    }
-
-    const parser = new MockFloatParser();
-    const metadataField = new MetadataField(parser);
-
-    expect(metadataField.rawValue).to.equal(undefined);
-    expect(metadataField.value).to.equal(undefined);
-    expect(metadataField.values).to.deep.equal([]);
-  });
-
   it('handles falsy `0` return values properly', () => {
     class MockFloatParser implements FieldParserInterface<number> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -47,4 +47,10 @@ describe('Metadata', () => {
     const metadata = new Metadata(json);
     expect(metadata.external_identifier?.values).to.deep.equal(['abc', '123']);
   });
+
+  it('returns undefined for fields that have not been provided', async () => {
+    const json = { identifier: 'foo', collection: ['abc', '123'] };
+    const metadata = new Metadata(json);
+    expect(metadata.runtime?.value).to.be.undefined;
+  });
 });

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -53,4 +53,12 @@ describe('Metadata', () => {
     const metadata = new Metadata(json);
     expect(metadata.runtime?.value).to.be.undefined;
   });
+
+  it('accepts fields that have not been modeled', async () => {
+    const json = { identifier: 'foo', foo: ['abc', '123'] };
+    const metadata = new Metadata(json);
+    // foo hasn't been added to the Metadata class,
+    // but can be accessed via the rawMetadata property
+    expect(metadata.rawMetadata.foo).to.be.deep.equal(['abc', '123']);
+  });
 });

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -3,6 +3,11 @@ import { expect } from '@open-wc/testing';
 import { Metadata } from '../../src/models/metadata';
 
 describe('Metadata', () => {
+  it('properly instantiates metadata with no data', async () => {
+    const metadata = new Metadata();
+    expect(metadata.identifier).to.be.undefined;
+  });
+
   it('properly instantiates metadata with identifier', async () => {
     const json = { identifier: 'foo', collection: 'bar' };
     const metadata = new Metadata(json);

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -6,6 +6,7 @@ describe('Metadata', () => {
   it('properly instantiates metadata with no data', async () => {
     const metadata = new Metadata();
     expect(metadata.identifier).to.be.undefined;
+    expect(metadata.collection).to.be.undefined;
   });
 
   it('properly instantiates metadata with identifier', async () => {


### PR DESCRIPTION
All of the metadata fields are already readonly and memoized so this enforces consistency in the data.