### PR TITLE
WEBDEV-8572: Constrain reviews_allowed with a reusable EnumField

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 // top level models
 export { File } from './src/models/file';
 export { Metadata } from './src/models/metadata';
+export type { ReviewsAllowed } from './src/models/metadata';
 export { Review } from './src/models/review';
 export { SpeechMusicASREntry } from './src/models/speech-music-asr-entry';
 export { Task, TaskColor, TaskStatus } from './src/models/task';
@@ -10,6 +11,10 @@ export { BooleanField } from './src/models/metadata-fields/field-types/boolean';
 export { ByteField } from './src/models/metadata-fields/field-types/byte';
 export { DateField } from './src/models/metadata-fields/field-types/date';
 export { DurationField } from './src/models/metadata-fields/field-types/duration';
+export {
+  EnumField,
+  EnumParser,
+} from './src/models/metadata-fields/field-types/enum';
 export {
   ListField,
   NumberListField,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.0",
+  "version": "1.1.1-webdev-7872.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.1-webdev-7872.0",
+  "version": "1.1.1-webdev-8572.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.1-webdev-8572.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/models/metadata-fields/field-types/enum.ts
+++ b/src/models/metadata-fields/field-types/enum.ts
@@ -1,0 +1,47 @@
+import type { FieldParserInterface } from '@internetarchive/field-parsers';
+import { MetadataField, MetadataRawValue } from '../metadata-field';
+
+/**
+ * Parses a raw value against a fixed set of allowed string literals.
+ *
+ * Unlike the plain `StringParser`, this validates at runtime: any value not in
+ * the `allowed` set is rejected (returns `undefined`), so the parsed `value` and
+ * the field's TypeScript type stay in agreement.
+ *
+ * @class EnumParser
+ * @template T The union of allowed string literals (e.g. `'rl' | 'lr'`)
+ */
+export class EnumParser<T extends string> implements FieldParserInterface<T> {
+  constructor(private readonly allowed: readonly T[]) {}
+
+  parseValue(rawValue: string | number | boolean): T | undefined {
+    return typeof rawValue === 'string' &&
+      (this.allowed as readonly string[]).includes(rawValue)
+      ? (rawValue as T)
+      : undefined;
+  }
+}
+
+/**
+ * A field whose value is restricted to a fixed set of allowed string literals.
+ *
+ * Pass a (typically module-level, shared) `EnumParser` so the allowed set is
+ * defined once:
+ *
+ * ```
+ * const colorParser = new EnumParser<'red' | 'green' | 'blue'>(['red', 'green', 'blue']);
+ * const field = new EnumField('green', colorParser);
+ * field.value // 'green'  (typed as 'red' | 'green' | 'blue' | undefined)
+ * ```
+ *
+ * @class EnumField
+ * @template T The union of allowed string literals
+ */
+export class EnumField<T extends string> extends MetadataField<
+  T,
+  EnumParser<T>
+> {
+  constructor(rawValue: MetadataRawValue, parser: EnumParser<T>) {
+    super(parser, rawValue);
+  }
+}

--- a/src/models/metadata-fields/field-types/enum.ts
+++ b/src/models/metadata-fields/field-types/enum.ts
@@ -1,4 +1,7 @@
-import type { FieldParserInterface } from '@internetarchive/field-parsers';
+import type {
+  FieldParserInterface,
+  FieldParserRawValue,
+} from '@internetarchive/field-parsers';
 import { MetadataField, MetadataRawValue } from '../metadata-field';
 
 /**
@@ -14,7 +17,7 @@ import { MetadataField, MetadataRawValue } from '../metadata-field';
 export class EnumParser<T extends string> implements FieldParserInterface<T> {
   constructor(private readonly allowed: readonly T[]) {}
 
-  parseValue(rawValue: string | number | boolean): T | undefined {
+  parseValue(rawValue: FieldParserRawValue): T | undefined {
     return typeof rawValue === 'string' &&
       (this.allowed as readonly string[]).includes(rawValue)
       ? (rawValue as T)

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -8,6 +8,15 @@ import { PageProgressionField } from './metadata-fields/field-types/page-progres
 import { ByteField } from './metadata-fields/field-types/byte';
 import { MediaTypeField } from './metadata-fields/field-types/mediatype';
 import { StringListField } from './metadata-fields/field-types/list';
+import { EnumField, EnumParser } from './metadata-fields/field-types/enum';
+
+/** Allowed values for the `reviews-allowed` item metadata field. */
+export type ReviewsAllowed = 'true' | 'none' | 'frozen';
+const reviewsAllowedParser = new EnumParser<ReviewsAllowed>([
+  'true',
+  'none',
+  'frozen',
+]);
 
 /**
  * Metadata is an expansive model that describes an Item.
@@ -390,9 +399,12 @@ export class Metadata {
    * `none` (disabled), or `frozen` (existing reviews shown, no new ones).
    * Absent for most items, which means reviews are enabled.
    */
-  @Memoize() get reviews_allowed(): StringField | undefined {
+  @Memoize() get reviews_allowed(): EnumField<ReviewsAllowed> | undefined {
     return this.rawMetadata['reviews-allowed'] != null
-      ? new StringField(this.rawMetadata['reviews-allowed'])
+      ? new EnumField<ReviewsAllowed>(
+          this.rawMetadata['reviews-allowed'],
+          reviewsAllowedParser,
+        )
       : undefined;
   }
 

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -385,6 +385,17 @@ export class Metadata {
       : undefined;
   }
 
+  /**
+   * Whether reviews may be added to this item. One of `true` (enabled),
+   * `none` (disabled), or `frozen` (existing reviews shown, no new ones).
+   * Absent for most items, which means reviews are enabled.
+   */
+  @Memoize() get reviews_allowed(): StringField | undefined {
+    return this.rawMetadata['reviews-allowed'] != null
+      ? new StringField(this.rawMetadata['reviews-allowed'])
+      : undefined;
+  }
+
   @Memoize() get rights(): StringField | undefined {
     return this.rawMetadata.rights != null
       ? new StringField(this.rawMetadata.rights)

--- a/test/models/metadata-fields/field-types/enum.test.ts
+++ b/test/models/metadata-fields/field-types/enum.test.ts
@@ -1,0 +1,48 @@
+import { expect } from '@open-wc/testing';
+import {
+  EnumField,
+  EnumParser,
+} from '../../../../src/models/metadata-fields/field-types/enum';
+
+type Color = 'red' | 'green' | 'blue';
+const colorParser = new EnumParser<Color>(['red', 'green', 'blue']);
+
+describe('EnumField', () => {
+  it('parses an allowed value', () => {
+    const field = new EnumField<Color>('green', colorParser);
+
+    expect(field.value).to.equal('green');
+    expect(field.values).to.deep.equal(['green']);
+    expect(field.rawValue).to.equal('green');
+  });
+
+  it('rejects a value outside the allowed set', () => {
+    const field = new EnumField<Color>('purple', colorParser);
+
+    expect(field.value).to.be.undefined;
+    expect(field.values).to.deep.equal([]);
+    // the raw value is still preserved for inspection
+    expect(field.rawValue).to.equal('purple');
+  });
+
+  it('rejects non-string raw values', () => {
+    const field = new EnumField<Color>(123, colorParser);
+
+    expect(field.value).to.be.undefined;
+    expect(field.values).to.deep.equal([]);
+  });
+
+  it('filters a mixed array down to allowed values', () => {
+    const field = new EnumField<Color>(['red', 'purple', 'blue'], colorParser);
+
+    expect(field.values).to.deep.equal(['red', 'blue']);
+    expect(field.value).to.equal('red');
+  });
+
+  it('is generic over any allowed set', () => {
+    const sizeParser = new EnumParser<'sm' | 'lg'>(['sm', 'lg']);
+    const field = new EnumField<'sm' | 'lg'>('lg', sizeParser);
+
+    expect(field.value).to.equal('lg');
+  });
+});

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -49,6 +49,12 @@ describe('Metadata', () => {
     expect(metadata.external_identifier?.values).to.deep.equal(['abc', '123']);
   });
 
+  it('properly instantiates metadata with reviews-allowed', async () => {
+    const json = { identifier: 'foo', 'reviews-allowed': 'frozen' };
+    const metadata = new Metadata(json);
+    expect(metadata.reviews_allowed?.value).to.equal('frozen');
+  });
+
   it('returns undefined for fields that have not been provided', async () => {
     const json = { identifier: 'foo', collection: ['abc', '123'] };
     const metadata = new Metadata(json);

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -55,6 +55,24 @@ describe('Metadata', () => {
     expect(metadata.reviews_allowed?.value).to.equal('frozen');
   });
 
+  it('accepts all valid reviews-allowed values', async () => {
+    for (const value of ['true', 'none', 'frozen']) {
+      const metadata = new Metadata({
+        identifier: 'foo',
+        'reviews-allowed': value,
+      });
+      expect(metadata.reviews_allowed?.value).to.equal(value);
+    }
+  });
+
+  it('rejects an invalid reviews-allowed value', async () => {
+    const json = { identifier: 'foo', 'reviews-allowed': 'maybe' };
+    const metadata = new Metadata(json);
+    expect(metadata.reviews_allowed?.value).to.be.undefined;
+    // the raw value is still preserved for inspection
+    expect(metadata.reviews_allowed?.rawValue).to.equal('maybe');
+  });
+
   it('returns undefined for fields that have not been provided', async () => {
     const json = { identifier: 'foo', collection: ['abc', '123'] };
     const metadata = new Metadata(json);


### PR DESCRIPTION
## Summary

`reviews-allowed` only ever takes three values, but [WEBDEV-8572](https://webarchive.jira.com/browse/WEBDEV-8572) modeled it as a plain `StringField`. This adds a generic, **runtime-validating** `EnumField<T>` (backed by `EnumParser<T>`) and uses it to narrow `reviews_allowed` to `'true' | 'none' | 'frozen'`.

- **`EnumParser<T>` / `EnumField<T>`** — a new reusable field type in `src/models/metadata-fields/field-types/enum.ts`. Pass an allowed-values list; values outside the set parse to `undefined` (the raw value is still preserved on `.rawValue`). Mirrors the existing `ListParser`/`ListField` "parameterized parser + field" shape, but kept local — no `@internetarchive/field-parsers` change.
- **`reviews_allowed`** now returns `EnumField<ReviewsAllowed> | undefined`, so consumers (offshoot's `reviewsDisabled`/`reviewsFrozen` gating) get autocomplete + type-narrowing instead of a bare `string`.
- **Exports** `EnumField`, `EnumParser`, and the `ReviewsAllowed` union type.

### Why no dedicated parser in `field-parsers`?
The base `MetadataField` only needs *something* implementing `FieldParserInterface`; a local `EnumParser` satisfies that exactly like `MediaTypeParser` does today. Keeping it here makes this a single self-contained change. A follow-up will evaluate promoting `EnumParser` to `field-parsers` and migrating `MediaTypeField`/`PageProgressionField` onto it.

## Test plan
- New `test/models/metadata-fields/field-types/enum.test.ts`: valid values, out-of-set rejection (→ `undefined`, raw preserved), non-string rejection, mixed-array filtering, and genericity over a different allowed set.
- Extended `test/models/metadata.test.ts`: all three valid `reviews-allowed` values + an invalid value.
- `npm run test` green (`tsc`, `eslint`, `prettier`, `madge` circular, `wtr --coverage`). The one `addeddate` failure under local TZ is a pre-existing timezone-dependent test (passes under `TZ=UTC`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8572]: https://webarchive.jira.com/browse/WEBDEV-8572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ