### PR TITLE
v1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/iaux-item-metadata",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/iaux-item-metadata",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Stable release cutting the `reviews_allowed` Metadata field (WEBDEV-8572, merged in #46) as 1.1.0 → 1.1.1. Version-only bump (package.json + package-lock.json); no code changes. Tag `v1.1.1` to follow on merge; publish to npm handled manually.