### PR TITLE
WEBDEV-8638: Make addeddate Date test timezone-independent

### DIFF
--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -19,14 +19,7 @@ describe('Metadata', () => {
     const json = { identifier: 'foo', addeddate: '2021-05-20T13:37:15Z' };
     const metadata = new Metadata(json);
 
-    const expected = new Date();
-    expected.setHours(13);
-    expected.setMinutes(37);
-    expected.setSeconds(15);
-    expected.setMilliseconds(0);
-    expected.setMonth(4);
-    expected.setDate(20);
-    expected.setFullYear(2021);
+    const expected = new Date(Date.UTC(2021, 4, 20, 13, 37, 15));
 
     expect(metadata.addeddate?.value?.getTime()).to.equal(expected.getTime());
   });


### PR DESCRIPTION
## What
`test/models/metadata.test.ts` built the `addeddate` test's `expected` Date with local-time setters and compared `.getTime()` against the parsed input `'2021-05-20T13:37:15Z'` (an absolute UTC instant). The epochs only matched when the runner's timezone was UTC — green in CI, failing locally (e.g. PDT, off by 7h: `expected 1621517835000 to equal 1621543035000`).

## Fix
Build `expected` from explicit UTC components — `new Date(Date.UTC(2021, 4, 20, 13, 37, 15))` — so the assertion is timezone-independent.

## Scope
`review.test.ts` uses the same setter style, but its inputs (`'2014-05-09 09:47:15'`, `'0'`) are parsed as **local** time (no `Z`), so expected-local == actual-local in every zone — TZ-robust, left unchanged.

Test-only; no runtime change. Full suite green locally in PDT (69 passed, 0 failed).