### PR TITLE
WEBDEV-8687: Back MediaTypeField/PageProgressionField with EnumField

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -23,6 +23,7 @@ interface FieldRow {
 const FIELDS: FieldRow[] = [
   { label: 'title', get: m => m.title },
   { label: 'mediatype', get: m => m.mediatype },
+  { label: 'page_progression', get: m => m.page_progression },
   { label: 'creator', get: m => m.creator },
   { label: 'collection', get: m => m.collection },
   { label: 'subject', get: m => m.subject },

--- a/index.ts
+++ b/index.ts
@@ -21,8 +21,10 @@ export {
   StringListField
 } from './src/models/metadata-fields/field-types/list';
 export { MediaTypeField } from './src/models/metadata-fields/field-types/mediatype';
+export type { MediaType } from './src/models/metadata-fields/field-types/mediatype';
 export { NumberField } from './src/models/metadata-fields/field-types/number';
 export { PageProgressionField } from './src/models/metadata-fields/field-types/page-progression';
+export type { PageProgression } from './src/models/metadata-fields/field-types/page-progression';
 export { StringField } from './src/models/metadata-fields/field-types/string';
 
 // base metadata field models

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/iaux-item-metadata",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/iaux-item-metadata",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/models/metadata-fields/field-types/mediatype.ts
+++ b/src/models/metadata-fields/field-types/mediatype.ts
@@ -1,8 +1,42 @@
-import { MediaType, MediaTypeParser } from '@internetarchive/field-parsers';
-import { MetadataField, MetadataRawValue } from '../metadata-field';
+import { MetadataRawValue } from '../metadata-field';
+import { EnumField, EnumParser } from './enum';
 
-export class MediaTypeField extends MetadataField<MediaType, MediaTypeParser> {
+/** Allowed values for the `mediatype` item metadata field. */
+export type MediaType =
+  | 'account'
+  | 'audio'
+  | 'collection'
+  | 'data'
+  | 'etree'
+  | 'image'
+  | 'movies'
+  | 'search'
+  | 'software'
+  | 'texts'
+  | 'web';
+
+const mediaTypeParser = new EnumParser<MediaType>([
+  'account',
+  'audio',
+  'collection',
+  'data',
+  'etree',
+  'image',
+  'movies',
+  'search',
+  'software',
+  'texts',
+  'web'
+]);
+
+/**
+ * A field whose value is restricted to the allowed `mediatype` values.
+ *
+ * Backed by an {@link EnumParser}, so a raw value outside the allowed set is
+ * rejected: `value` is `undefined` while `rawValue` keeps the original input.
+ */
+export class MediaTypeField extends EnumField<MediaType> {
   constructor(rawValue: MetadataRawValue) {
-    super(MediaTypeParser.shared, rawValue);
+    super(rawValue, mediaTypeParser);
   }
 }

--- a/src/models/metadata-fields/field-types/page-progression.ts
+++ b/src/models/metadata-fields/field-types/page-progression.ts
@@ -1,14 +1,19 @@
-import {
-  PageProgression,
-  PageProgressionParser
-} from '@internetarchive/field-parsers';
-import { MetadataField, MetadataRawValue } from '../metadata-field';
+import { MetadataRawValue } from '../metadata-field';
+import { EnumField, EnumParser } from './enum';
 
-export class PageProgressionField extends MetadataField<
-  PageProgression,
-  PageProgressionParser
-> {
+/** Allowed values for the `page_progression` item metadata field. */
+export type PageProgression = 'rl' | 'lr';
+
+const pageProgressionParser = new EnumParser<PageProgression>(['rl', 'lr']);
+
+/**
+ * A field whose value is restricted to the allowed `page_progression` values.
+ *
+ * Backed by an {@link EnumParser}, so a raw value outside the allowed set is
+ * rejected: `value` is `undefined` while `rawValue` keeps the original input.
+ */
+export class PageProgressionField extends EnumField<PageProgression> {
   constructor(rawValue: MetadataRawValue) {
-    super(PageProgressionParser.shared, rawValue);
+    super(rawValue, pageProgressionParser);
   }
 }

--- a/test/models/metadata-fields/field-types/mediatype.test.ts
+++ b/test/models/metadata-fields/field-types/mediatype.test.ts
@@ -1,20 +1,40 @@
 import { describe, it, expect } from 'vitest';
 import { MediaTypeField } from '../../../../src/models/metadata-fields/field-types/mediatype';
 
-describe('MediaTypeField Field', () => {
-  it('can parse a mediatype', () => {
+describe('MediaTypeField', () => {
+  it('parses a valid mediatype', () => {
     const field = new MediaTypeField('movies');
 
-    expect(field.value).to.be.equal('movies');
+    expect(field.value).to.equal('movies');
     expect(field.values).to.deep.equal(['movies']);
     expect(field.rawValue).to.equal('movies');
   });
 
-  it('can parse a mediatype', () => {
+  it('accepts all valid mediatype values', () => {
+    const values = [
+      'account',
+      'audio',
+      'collection',
+      'data',
+      'etree',
+      'image',
+      'movies',
+      'search',
+      'software',
+      'texts',
+      'web'
+    ];
+    for (const value of values) {
+      expect(new MediaTypeField(value).value).to.equal(value);
+    }
+  });
+
+  it('rejects an invalid mediatype', () => {
     const field = new MediaTypeField('blah');
 
-    expect(field.value).to.be.equal('blah');
-    expect(field.values).to.deep.equal(['blah']);
+    expect(field.value).to.be.undefined;
+    expect(field.values).to.deep.equal([]);
+    // the raw value is still preserved for inspection
     expect(field.rawValue).to.equal('blah');
   });
 });

--- a/test/models/metadata-fields/field-types/page-progression.test.ts
+++ b/test/models/metadata-fields/field-types/page-progression.test.ts
@@ -2,19 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { PageProgressionField } from '../../../../src/models/metadata-fields/field-types/page-progression';
 
 describe('PageProgressionField', () => {
-  it('can parse a page progression', () => {
+  it('parses a valid page progression', () => {
     const field = new PageProgressionField('rl');
 
-    expect(field.value).to.be.equal('rl');
+    expect(field.value).to.equal('rl');
     expect(field.values).to.deep.equal(['rl']);
     expect(field.rawValue).to.equal('rl');
   });
 
-  it('accepts any value', () => {
+  it('accepts all valid page progression values', () => {
+    for (const value of ['rl', 'lr']) {
+      expect(new PageProgressionField(value).value).to.equal(value);
+    }
+  });
+
+  it('rejects an invalid page progression', () => {
     const field = new PageProgressionField('blah');
 
-    expect(field.value).to.be.equal('blah');
-    expect(field.values).to.deep.equal(['blah']);
+    expect(field.value).to.be.undefined;
+    expect(field.values).to.deep.equal([]);
+    // the raw value is still preserved for inspection
     expect(field.rawValue).to.equal('blah');
   });
 });

--- a/test/models/metadata.test.ts
+++ b/test/models/metadata.test.ts
@@ -66,6 +66,34 @@ describe('Metadata', () => {
     expect(metadata.reviews_allowed?.rawValue).to.equal('maybe');
   });
 
+  it('properly instantiates metadata with mediatype', async () => {
+    const json = { identifier: 'foo', mediatype: 'texts' };
+    const metadata = new Metadata(json);
+    expect(metadata.mediatype?.value).to.equal('texts');
+  });
+
+  it('rejects an invalid mediatype value', async () => {
+    const json = { identifier: 'foo', mediatype: 'blah' };
+    const metadata = new Metadata(json);
+    expect(metadata.mediatype?.value).to.be.undefined;
+    // the raw value is still preserved for inspection
+    expect(metadata.mediatype?.rawValue).to.equal('blah');
+  });
+
+  it('properly instantiates metadata with page_progression', async () => {
+    const json = { identifier: 'foo', page_progression: 'rl' };
+    const metadata = new Metadata(json);
+    expect(metadata.page_progression?.value).to.equal('rl');
+  });
+
+  it('rejects an invalid page_progression value', async () => {
+    const json = { identifier: 'foo', page_progression: 'blah' };
+    const metadata = new Metadata(json);
+    expect(metadata.page_progression?.value).to.be.undefined;
+    // the raw value is still preserved for inspection
+    expect(metadata.page_progression?.rawValue).to.equal('blah');
+  });
+
   it('returns undefined for fields that have not been provided', async () => {
     const json = { identifier: 'foo', collection: ['abc', '123'] };
     const metadata = new Metadata(json);


### PR DESCRIPTION
Switches the `mediatype` and `page_progression` fields to the validating `EnumParser` (same pattern as `reviews_allowed`) instead of the casting parsers from field-parsers. An unknown value now comes back as `value: undefined` with `rawValue` preserved, instead of being silently cast to the type.

Public API is unchanged: `MediaTypeField` / `PageProgressionField` and the getter return types are the same, just `EnumField`-backed now. The `MediaType` / `PageProgression` types now live in this package and are exported.

Pairs with the field-parsers deprecation: internetarchive/iaux-field-parsers#11 (WEBDEV-8687).

WEBDEV-8687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADu4aSJNrToPTHkdS1Jokp
