### PR TITLE
WEBDEV-8687: Require field-parsers ^1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@internetarchive/field-parsers": "^1.0.0",
+        "@internetarchive/field-parsers": "^1.1.1",
         "typescript-memoize": "^1.1.1"
       },
       "devDependencies": {
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@internetarchive/field-parsers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-1.0.0.tgz",
-      "integrity": "sha512-cbD0FtJOjzBm7exxFrzrkHnqbmalKbEXA4i7KrwhUGBojF/QTTLAvaIRXH/bfoiTyCh6YT1/E/mULAQPdB6yvQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/field-parsers/-/field-parsers-1.1.1.tgz",
+      "integrity": "sha512-zYiXKsV31z2/QF9V6tLD5qun0Razr8HVs40tgFT2n6406Quf7V+7SbOjwhx7yMD1Y7qaeNJM5DDA/80CdEaP8w==",
       "license": "AGPL-3.0-only"
     },
     "node_modules/@jridgewell/resolve-uri": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ghpages:generate": "gh-pages -t -d ghpages -m \"Build for $(git log --pretty=format:\"%h %an %ai %s\" -n1) [skip ci]\""
   },
   "dependencies": {
-    "@internetarchive/field-parsers": "^1.0.0",
+    "@internetarchive/field-parsers": "^1.1.1",
     "typescript-memoize": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the field-parsers dep to ^1.1.1 so item-metadata resolves the release that marks the old mediatype/pageprogression parsers @deprecated (field-parsers#11). Dep + lockfile only, no code change.

WEBDEV-8687

🤖 Generated with [Claude Code](https://claude.com/claude-code)