### PR TITLE
WEBDEV-8714: Apply a shared parse helper to File & Review models

### DIFF
--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -6,6 +6,7 @@ import {
   DurationParser,
   NumberParser
 } from '@internetarchive/field-parsers';
+import { parseField } from './parse-field';
 
 /**
  * This represents an Internet Archive File
@@ -60,9 +61,11 @@ export class File {
   }
 
   @Memoize() get size(): Byte | undefined {
-    return this.rawValue.size != null
-      ? ByteParser.shared.parseValue(this.rawValue.size)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => ByteParser.shared.parseValue(v),
+      'size'
+    );
   }
 
   get title(): string | undefined {
@@ -70,27 +73,35 @@ export class File {
   }
 
   @Memoize() get length(): Duration | undefined {
-    return this.rawValue.length != null
-      ? DurationParser.shared.parseValue(this.rawValue.length)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => DurationParser.shared.parseValue(v),
+      'length'
+    );
   }
 
   @Memoize() get height(): number | undefined {
-    return this.rawValue.height != null
-      ? NumberParser.shared.parseValue(this.rawValue.height)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => NumberParser.shared.parseValue(v),
+      'height'
+    );
   }
 
   @Memoize() get width(): number | undefined {
-    return this.rawValue.width != null
-      ? NumberParser.shared.parseValue(this.rawValue.width)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => NumberParser.shared.parseValue(v),
+      'width'
+    );
   }
 
   @Memoize() get track(): number | undefined {
-    return this.rawValue.track != null
-      ? NumberParser.shared.parseValue(this.rawValue.track)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => NumberParser.shared.parseValue(v),
+      'track'
+    );
   }
 
   get external_identifier(): string | string[] | undefined {

--- a/src/models/parse-field.ts
+++ b/src/models/parse-field.ts
@@ -1,0 +1,23 @@
+import { FieldParserRawValue } from '@internetarchive/field-parsers';
+
+/**
+ * Parses the first of `keys` whose raw value is present in `raw`, using
+ * `parse`, or returns `undefined` if none are set. `parse` runs only on a
+ * present value, so it never sees `null`/`undefined`. Later keys act as
+ * fallbacks, for values that arrive under more than one name.
+ *
+ * @param raw The raw record to read from
+ * @param parse Parses a present raw value (e.g. `v => DateParser.shared.parseValue(v)`)
+ * @param keys The key(s) to read, in priority order
+ */
+export function parseField<T>(
+  raw: Readonly<Record<string, unknown>>,
+  parse: (value: FieldParserRawValue) => T | undefined,
+  ...keys: string[]
+): T | undefined {
+  for (const key of keys) {
+    const value = raw[key];
+    if (value != null) return parse(value as FieldParserRawValue);
+  }
+  return undefined;
+}

--- a/src/models/review.ts
+++ b/src/models/review.ts
@@ -1,5 +1,6 @@
 import { Memoize } from 'typescript-memoize';
 import { DateParser, NumberParser } from '@internetarchive/field-parsers';
+import { parseField } from './parse-field';
 
 export class Review {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -22,21 +23,27 @@ export class Review {
   }
 
   @Memoize() get reviewdate(): Date | undefined {
-    return this.rawValue.reviewdate != null
-      ? DateParser.shared.parseValue(this.rawValue.reviewdate)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => DateParser.shared.parseValue(v),
+      'reviewdate'
+    );
   }
 
   @Memoize() get createdate(): Date | undefined {
-    return this.rawValue.createdate != null
-      ? DateParser.shared.parseValue(this.rawValue.createdate)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => DateParser.shared.parseValue(v),
+      'createdate'
+    );
   }
 
   @Memoize() get stars(): number | undefined {
-    return this.rawValue.stars != null
-      ? NumberParser.shared.parseValue(this.rawValue.stars)
-      : undefined;
+    return parseField(
+      this.rawValue,
+      v => NumberParser.shared.parseValue(v),
+      'stars'
+    );
   }
 
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/test/models/parse-field.test.ts
+++ b/test/models/parse-field.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseField } from '../../src/models/parse-field';
+
+describe('parseField', () => {
+  it('parses the value of a present key', () => {
+    expect(parseField({ a: '5' }, v => Number(v), 'a')).to.equal(5);
+  });
+
+  it('returns undefined when the key is absent', () => {
+    expect(parseField({ a: '5' }, v => Number(v), 'missing')).to.be.undefined;
+    expect(parseField({}, v => Number(v), 'a')).to.be.undefined;
+  });
+
+  it('treats falsy-but-present values as present', () => {
+    expect(parseField({ a: 0 }, v => v, 'a')).to.equal(0);
+    expect(parseField({ a: '' }, v => v, 'a')).to.equal('');
+    expect(parseField({ a: false }, v => v, 'a')).to.equal(false);
+  });
+
+  it('skips null/undefined keys without calling parse', () => {
+    let calls = 0;
+    const result = parseField(
+      { a: null, b: undefined },
+      v => {
+        calls += 1;
+        return v;
+      },
+      'a',
+      'b'
+    );
+    expect(result).to.be.undefined;
+    expect(calls).to.equal(0);
+  });
+
+  it('falls back to a later key when earlier keys are absent', () => {
+    expect(parseField({ b: '7' }, v => Number(v), 'a', 'b')).to.equal(7);
+  });
+
+  it('uses the first present key when several are set', () => {
+    expect(parseField({ a: '1', b: '2' }, v => Number(v), 'a', 'b')).to.equal(
+      1
+    );
+  });
+
+  it('stops at the first present key even if parse returns undefined', () => {
+    let calls = 0;
+    const result = parseField<number>(
+      { a: 'x', b: 'y' },
+      () => {
+        calls += 1;
+        return undefined;
+      },
+      'a',
+      'b'
+    );
+    expect(result).to.be.undefined;
+    expect(calls).to.equal(1);
+  });
+});


### PR DESCRIPTION
Follow-up to #55 ([WEBDEV-8713](https://webarchive.jira.com/browse/WEBDEV-8713)), which added a field helper to the `Metadata` model.

`File` and `Review` repeat the same "null-check a raw key, transform, else undefined" shape, but they return raw parser output (`DateParser.shared.parseValue(raw)`) rather than field-class wrappers. Collapse that into a shared `parseField(raw, parse, ...keys)` free function used by both classes.

`file.ts` `mtime` is left alone — it multiplies the parsed number by 1000 and has its own null handling, so it doesn't fit the shape.

No behavior change: raw keys and parsers are unchanged (verified against `main`), and the suite passes (82/82, including a new direct unit test for `parseField`).

Note on the shape: this is deliberately a free function, whereas #55 uses private `field`/`fieldFrom` methods on `Metadata`. The transforms differ (field-class construction vs raw parser output) and so do the value types (`MetadataRawValue` includes arrays; `parseField` takes the scalar `FieldParserRawValue`). Kept them independent to avoid coupling two in-flight PRs; they could be folded into one primitive later if we want.

[WEBDEV-8714](https://webarchive.jira.com/browse/WEBDEV-8714)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8713]: https://webarchive.jira.com/browse/WEBDEV-8713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8714]: https://webarchive.jira.com/browse/WEBDEV-8714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ