### PR TITLE
WEBDEV-8804: Build the demo table from the model, add a field filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: App CI
 on:
   push:
     branches: [ main ]
+  # every pull request, whatever it targets, so a PR stacked on another
+  # branch still gets its tests run
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -81,6 +81,24 @@ function paramFromUrl(name: string): string | undefined {
   return value || undefined;
 }
 
+/**
+ * The filter split on commas, so `aspect, tuner` narrows to both rather than
+ * looking for one field with that whole string in its name.
+ */
+function filterTerms(query: string): string[] {
+  return query
+    .split(',')
+    .map(term => term.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** True when the filter is empty, or `name` contains any one of its terms. */
+function matchesFilter(name: string, terms: string[]): boolean {
+  if (!terms.length) return true;
+  const lower = name.toLowerCase();
+  return terms.some(term => lower.includes(term));
+}
+
 /** Render any parsed value (Date, number, string, array, object) as text. */
 function display(value: unknown): string {
   if (value === undefined || value === null) return '—';
@@ -106,7 +124,7 @@ export class AppRoot extends LitElement {
   /** Raw keys present in the response that no field reads. */
   @state() private unmodeledKeys: string[] = [];
 
-  /** Filters the table down to field names containing this text. */
+  /** Comma-separated terms; a field shows when its name contains any of them. */
   @state() private query = paramFromUrl(FILTER_PARAM) ?? '';
 
   /** Whether to keep rows for fields the item leaves unset. */
@@ -261,12 +279,12 @@ export class AppRoot extends LitElement {
 
       <div class="toolbar">
         <label class="field">
-          <span>Filter fields</span>
+          <span>Filter fields (comma separated)</span>
           <input
             type="search"
             .value=${this.query}
             @input=${this.onQueryInput}
-            placeholder="e.g. date, aspect, codec"
+            placeholder="e.g. aspect, tuner, scandate"
           />
         </label>
         <label class="toggle">
@@ -288,9 +306,9 @@ export class AppRoot extends LitElement {
    * unset (unless asked for) and the ones the filter excludes.
    */
   private visibleFields(metadata: Metadata): string[] {
-    const query = this.query.trim().toLowerCase();
+    const terms = filterTerms(this.query);
     return MODELED_FIELDS.filter(name => {
-      if (query && !name.toLowerCase().includes(query)) return false;
+      if (!matchesFilter(name, terms)) return false;
       return this.showUnset || fieldValue(metadata, name) !== undefined;
     });
   }
@@ -350,10 +368,8 @@ export class AppRoot extends LitElement {
    */
   private renderUnmodeled() {
     if (!this.unmodeledKeys.length) return nothing;
-    const query = this.query.trim().toLowerCase();
-    const keys = query
-      ? this.unmodeledKeys.filter(key => key.toLowerCase().includes(query))
-      : this.unmodeledKeys;
+    const terms = filterTerms(this.query);
+    const keys = this.unmodeledKeys.filter(key => matchesFilter(key, terms));
 
     return html`
       <details class="unmodeled">
@@ -390,13 +406,22 @@ export class AppRoot extends LitElement {
     const url = new URL(window.location.href);
     const params: Record<string, string> = {
       [IDENTIFIER_PARAM]: this.identifier,
-      [FILTER_PARAM]: this.query
+      // The canonical term list rather than the raw text, so the shared link
+      // stays tidy however the filter was typed.
+      [FILTER_PARAM]: filterTerms(this.query).join(',')
     };
     for (const [name, value] of Object.entries(params)) {
       if (value.trim()) url.searchParams.set(name, value.trim());
       else url.searchParams.delete(name);
     }
-    window.history.replaceState({}, '', url);
+    // Commas are legal unencoded in a query string and a multi-field filter
+    // reads far better in a shared link, so undo the percent-encoding.
+    const search = url.search.replace(/%2C/g, ',');
+    window.history.replaceState(
+      {},
+      '',
+      `${url.origin}${url.pathname}${search}`
+    );
   }
 
   private onShowUnsetChange(event: Event): void {

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -241,13 +241,11 @@ export class AppRoot extends LitElement {
         Try:
         ${EXAMPLES.map(
           id =>
-            html`<button
-              type="button"
-              class="link"
-              @click=${() => this.useExample(id)}
-            >
-              ${id}
-            </button>`
+            html`<a
+              href=${this.exampleHref(id)}
+              @click=${(event: MouseEvent) => this.onExampleClick(event, id)}
+              >${id}</a
+            >`
         )}
       </p>
 
@@ -449,7 +447,30 @@ export class AppRoot extends LitElement {
     void this.loadFromArchive();
   }
 
-  private useExample(id: string): void {
+  /**
+   * Where an example link points: this page with that item loaded, keeping any
+   * filter that's already on. Real hrefs so the examples can be opened in a
+   * tab or copied like any other link.
+   */
+  private exampleHref(id: string): string {
+    const params = new URLSearchParams({ [IDENTIFIER_PARAM]: id });
+    const filter = filterTerms(this.query).join(',');
+    if (filter) params.set(FILTER_PARAM, filter);
+    return `?${params.toString().replace(/%2C/g, ',')}`;
+  }
+
+  private onExampleClick(event: MouseEvent, id: string): void {
+    // leave the modified clicks alone, they mean open it somewhere else
+    if (
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
     this.identifier = id;
     void this.loadFromArchive();
   }
@@ -473,7 +494,7 @@ export class AppRoot extends LitElement {
 
     /* identifiers are long unbroken tokens and will push the page sideways */
     h2,
-    .examples button {
+    .examples a {
       overflow-wrap: anywhere;
     }
 
@@ -525,15 +546,6 @@ export class AppRoot extends LitElement {
       cursor: default;
     }
 
-    button.link {
-      background: none;
-      border: none;
-      color: #194880;
-      text-decoration: underline;
-      padding: 0;
-      cursor: pointer;
-    }
-
     .examples {
       font-size: 0.85rem;
       color: #555;
@@ -541,6 +553,10 @@ export class AppRoot extends LitElement {
       gap: 0.75rem;
       flex-wrap: wrap;
       align-items: baseline;
+    }
+
+    .examples a {
+      color: #194880;
     }
 
     details {

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -35,6 +35,18 @@ function isMetadataField(
 }
 
 /**
+ * The field class that parsed a value, e.g. `DateField`. Read off the
+ * constructor rather than a lookup table so a new field type names itself,
+ * which is why the demo build leaves class names unminified.
+ */
+function fieldTypeName(value: unknown): string {
+  if (value === undefined) return '—';
+  if (isMetadataField(value)) return value.constructor?.name ?? 'unknown';
+  // `identifier` is handed back as a plain string
+  return typeof value;
+}
+
+/**
  * The raw keys the model reads, collected by handing `Metadata` a Proxy over the
  * raw response and then touching every field. Comparing getter names to raw keys
  * would miss the cases that matter here: keys that differ from their getter
@@ -326,19 +338,22 @@ export class AppRoot extends LitElement {
       </p>
       ${fields.length
         ? html`
-            <table>
-              <thead>
-                <tr>
-                  <th>Field</th>
-                  <th><code>.value</code></th>
-                  <th><code>.values</code></th>
-                  <th><code>.rawValue</code></th>
-                </tr>
-              </thead>
-              <tbody>
-                ${fields.map(name => this.renderRow(metadata, name))}
-              </tbody>
-            </table>
+            <div class="table-scroll">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Field</th>
+                    <th>Parsed as</th>
+                    <th><code>.value</code></th>
+                    <th><code>.values</code></th>
+                    <th><code>.rawValue</code></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${fields.map(name => this.renderRow(metadata, name))}
+                </tbody>
+              </table>
+            </div>
           `
         : html`<p class="meta">No field names match that filter.</p>`}
     `;
@@ -355,6 +370,7 @@ export class AppRoot extends LitElement {
     return html`
       <tr class=${value === undefined ? 'unset' : ''}>
         <td><code>${name}</code></td>
+        <td class="type">${fieldTypeName(value)}</td>
         <td>${cells[0]}</td>
         <td>${cells[1]}</td>
         <td class="raw">${cells[2]}</td>
@@ -441,11 +457,24 @@ export class AppRoot extends LitElement {
   static styles = css`
     :host {
       display: block;
-      max-width: 60rem;
+      /* wide enough for the structured values, which run long as JSON */
+      max-width: 110rem;
       margin: 0 auto;
       padding: 1rem;
       color: #222;
       line-height: 1.4;
+    }
+
+    /* the prose reads badly at the full table width */
+    h1,
+    :host > p {
+      max-width: 60rem;
+    }
+
+    /* identifiers are long unbroken tokens and will push the page sideways */
+    h2,
+    .examples button {
+      overflow-wrap: anywhere;
     }
 
     h1 {
@@ -586,10 +615,28 @@ export class AppRoot extends LitElement {
       font-size: 0.8rem;
     }
 
+    /* keep a wide table inside its own scroller rather than stretching the page */
+    .table-scroll {
+      overflow-x: auto;
+      max-width: 100%;
+    }
+
     table {
       border-collapse: collapse;
       width: 100%;
       font-size: 0.9rem;
+    }
+
+    td.type {
+      color: #555;
+      font-family: monospace;
+      font-size: 0.8rem;
+      white-space: nowrap;
+    }
+
+    /* the field name and its type are the anchors, so keep them intact */
+    tbody td:first-child {
+      white-space: nowrap;
     }
 
     th,

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -9,39 +9,49 @@ interface MetadataApiResponse {
   files?: unknown[];
 }
 
-/** A field on `Metadata` we want to surface in the demo table. */
-interface FieldRow {
-  label: string;
-  get: (metadata: Metadata) => MetadataFieldInterface<unknown> | undefined;
+/**
+ * Every field the model exposes, read off `Metadata`'s prototype getters. The
+ * table is built from this, so a field added to the model shows up in the demo
+ * without anyone touching this file. Sorted to give the table a stable order.
+ */
+const MODELED_FIELDS: string[] = Object.getOwnPropertyNames(Metadata.prototype)
+  .filter(
+    name =>
+      typeof Object.getOwnPropertyDescriptor(Metadata.prototype, name)?.get ===
+      'function'
+  )
+  .sort();
+
+/** Reads a field off the model by name. */
+function fieldValue(metadata: Metadata, name: string): unknown {
+  return (metadata as unknown as Record<string, unknown>)[name];
+}
+
+/** True for parsed field objects (`StringField`, `DateField`, and friends). */
+function isMetadataField(
+  value: unknown
+): value is MetadataFieldInterface<unknown> {
+  return typeof value === 'object' && value !== null && 'rawValue' in value;
 }
 
 /**
- * The fields rendered in the parsed-values table. Each shows how the model
- * normalizes the raw API value into a native type. Music-specific fields
- * (venue, taper, source, lineage) populate for live-recording items.
+ * The raw keys the model reads, collected by handing `Metadata` a Proxy over the
+ * raw response and then touching every field. Comparing getter names to raw keys
+ * would miss the cases that matter here: keys that differ from their getter
+ * (`access-restricted-item`) and fields that fall back across several keys.
  */
-const FIELDS: FieldRow[] = [
-  { label: 'title', get: m => m.title },
-  { label: 'mediatype', get: m => m.mediatype },
-  { label: 'page_progression', get: m => m.page_progression },
-  { label: 'creator', get: m => m.creator },
-  { label: 'collection', get: m => m.collection },
-  { label: 'subject', get: m => m.subject },
-  { label: 'description', get: m => m.description },
-  { label: 'date', get: m => m.date },
-  { label: 'addeddate', get: m => m.addeddate },
-  { label: 'publicdate', get: m => m.publicdate },
-  { label: 'language', get: m => m.language },
-  { label: 'duration', get: m => m.duration },
-  { label: 'runtime', get: m => m.runtime },
-  { label: 'downloads', get: m => m.downloads },
-  { label: 'item_size', get: m => m.item_size },
-  { label: 'files_count', get: m => m.files_count },
-  { label: 'venue', get: m => m.venue },
-  { label: 'taper', get: m => m.taper },
-  { label: 'source', get: m => m.source },
-  { label: 'lineage', get: m => m.lineage }
-];
+function modeledRawKeys(raw: Record<string, unknown>): Set<string> {
+  const touched = new Set<string>();
+  const probe = new Proxy(raw, {
+    get(target, key) {
+      if (typeof key === 'string') touched.add(key);
+      return Reflect.get(target, key);
+    }
+  });
+  const metadata = new Metadata(probe);
+  for (const name of MODELED_FIELDS) fieldValue(metadata, name);
+  return touched;
+}
 
 /**
  * A few stable archive.org items demonstrating different metadata shapes.
@@ -57,6 +67,19 @@ const EXAMPLES = [
   'womeningovernmen0000jame'
 ];
 
+/**
+ * Query params the demo reads on load and keeps up to date, so a link can point
+ * someone at a particular item with the table already filtered.
+ */
+const IDENTIFIER_PARAM = 'identifier';
+const FILTER_PARAM = 'filter';
+
+/** A trimmed query param off the current URL, or undefined if absent or blank. */
+function paramFromUrl(name: string): string | undefined {
+  const value = new URLSearchParams(window.location.search).get(name)?.trim();
+  return value || undefined;
+}
+
 /** Render any parsed value (Date, number, string, array, object) as text. */
 function display(value: unknown): string {
   if (value === undefined || value === null) return '—';
@@ -69,7 +92,7 @@ function display(value: unknown): string {
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
-  @state() private identifier = EXAMPLES[0];
+  @state() private identifier = paramFromUrl(IDENTIFIER_PARAM) ?? EXAMPLES[0];
 
   @state() private metadata?: Metadata;
 
@@ -78,6 +101,15 @@ export class AppRoot extends LitElement {
   @state() private loading = false;
 
   @state() private error?: string;
+
+  /** Raw keys present in the response that no field reads. */
+  @state() private unmodeledKeys: string[] = [];
+
+  /** Filters the table down to field names containing this text. */
+  @state() private query = paramFromUrl(FILTER_PARAM) ?? '';
+
+  /** Whether to keep rows for fields the item leaves unset. */
+  @state() private showUnset = false;
 
   protected firstUpdated(): void {
     // Populate the table on load so the demo shows real data immediately.
@@ -104,15 +136,26 @@ export class AppRoot extends LitElement {
       if (!json.metadata) {
         throw new Error(`No item found for identifier “${identifier}”.`);
       }
-      this.metadata = new Metadata(json.metadata);
+      this.setMetadata(json.metadata);
       this.fileCount = json.files?.length;
+      this.syncUrl();
     } catch (e) {
       this.metadata = undefined;
       this.fileCount = undefined;
+      this.unmodeledKeys = [];
       this.error = e instanceof Error ? e.message : 'Failed to load item.';
     } finally {
       this.loading = false;
     }
+  }
+
+  /** Builds the model and works out which raw keys it leaves untouched. */
+  private setMetadata(raw: Record<string, unknown>): void {
+    this.metadata = new Metadata(raw);
+    const modeled = modeledRawKeys(raw);
+    this.unmodeledKeys = Object.keys(raw)
+      .filter(key => !modeled.has(key))
+      .sort();
   }
 
   private parseJson(): void {
@@ -126,7 +169,7 @@ export class AppRoot extends LitElement {
       const parsed = JSON.parse(text) as Record<string, unknown>;
       // Accept either a full API response or a bare metadata object.
       const raw = (parsed.metadata as Record<string, unknown>) ?? parsed;
-      this.metadata = new Metadata(raw);
+      this.setMetadata(raw);
       this.fileCount = undefined;
       this.error = undefined;
     } catch {
@@ -143,7 +186,9 @@ export class AppRoot extends LitElement {
           >archive.org</a
         >
         item metadata. Load an item by identifier (or paste raw JSON) to see how
-        each field is normalized from its raw API value into a native type.
+        each field is normalized from its raw API value into a native type. The
+        item and field filter stay in the URL, so you can link straight to a
+        view.
       </p>
 
       <form class="controls" @submit=${this.onSubmit}>
@@ -213,35 +258,148 @@ export class AppRoot extends LitElement {
         ? html`<p class="meta">${this.fileCount} files in response</p>`
         : nothing}
 
-      <table>
-        <thead>
-          <tr>
-            <th>Field</th>
-            <th><code>.value</code></th>
-            <th><code>.values</code></th>
-            <th><code>.rawValue</code></th>
-          </tr>
-        </thead>
-        <tbody>
-          ${FIELDS.map(field => {
-            const parsed = field.get(metadata);
-            if (!parsed) return nothing;
-            return html`
-              <tr>
-                <td><code>${field.label}</code></td>
-                <td>${display(parsed.value)}</td>
-                <td>${display(parsed.values)}</td>
-                <td class="raw">${display(parsed.rawValue)}</td>
-              </tr>
-            `;
-          })}
-        </tbody>
-      </table>
+      <div class="toolbar">
+        <label class="field">
+          <span>Filter fields</span>
+          <input
+            type="search"
+            .value=${this.query}
+            @input=${this.onQueryInput}
+            placeholder="e.g. date, aspect, codec"
+          />
+        </label>
+        <label class="toggle">
+          <input
+            type="checkbox"
+            .checked=${this.showUnset}
+            @change=${this.onShowUnsetChange}
+          />
+          <span>Show unset fields</span>
+        </label>
+      </div>
+
+      ${this.renderTable(metadata)} ${this.renderUnmodeled()}
+    `;
+  }
+
+  /**
+   * The fields to show: every modeled field, minus the ones this item leaves
+   * unset (unless asked for) and the ones the filter excludes.
+   */
+  private visibleFields(metadata: Metadata): string[] {
+    const query = this.query.trim().toLowerCase();
+    return MODELED_FIELDS.filter(name => {
+      if (query && !name.toLowerCase().includes(query)) return false;
+      return this.showUnset || fieldValue(metadata, name) !== undefined;
+    });
+  }
+
+  private renderTable(metadata: Metadata) {
+    const fields = this.visibleFields(metadata);
+    const setCount = MODELED_FIELDS.filter(
+      name => fieldValue(metadata, name) !== undefined
+    ).length;
+
+    return html`
+      <p class="meta">
+        Showing ${fields.length} of ${MODELED_FIELDS.length} modeled fields.
+        ${setCount} set on this item.
+      </p>
+      ${fields.length
+        ? html`
+            <table>
+              <thead>
+                <tr>
+                  <th>Field</th>
+                  <th><code>.value</code></th>
+                  <th><code>.values</code></th>
+                  <th><code>.rawValue</code></th>
+                </tr>
+              </thead>
+              <tbody>
+                ${fields.map(name => this.renderRow(metadata, name))}
+              </tbody>
+            </table>
+          `
+        : html`<p class="meta">No field names match that filter.</p>`}
+    `;
+  }
+
+  private renderRow(metadata: Metadata, name: string) {
+    const value = fieldValue(metadata, name);
+    // `identifier` is a plain string rather than a parsed field, so it has a
+    // value but no `.values` / `.rawValue` to show.
+    const cells = isMetadataField(value)
+      ? [display(value.value), display(value.values), display(value.rawValue)]
+      : [display(value), display(undefined), display(undefined)];
+
+    return html`
+      <tr class=${value === undefined ? 'unset' : ''}>
+        <td><code>${name}</code></td>
+        <td>${cells[0]}</td>
+        <td>${cells[1]}</td>
+        <td class="raw">${cells[2]}</td>
+      </tr>
+    `;
+  }
+
+  /**
+   * Raw keys the model doesn't read, so a field missing from the table above
+   * reads as a gap in the model rather than a gap in this demo.
+   */
+  private renderUnmodeled() {
+    if (!this.unmodeledKeys.length) return nothing;
+    const query = this.query.trim().toLowerCase();
+    const keys = query
+      ? this.unmodeledKeys.filter(key => key.toLowerCase().includes(query))
+      : this.unmodeledKeys;
+
+    return html`
+      <details class="unmodeled">
+        <summary>
+          ${keys.length === this.unmodeledKeys.length
+            ? this.unmodeledKeys.length
+            : `${keys.length} of ${this.unmodeledKeys.length}`}
+          raw keys the model doesn't expose
+        </summary>
+        ${keys.length
+          ? html`<p class="keys">
+              ${keys.map(key => html`<code>${key}</code>`)}
+            </p>`
+          : html`<p class="meta">No unmodeled keys match that filter.</p>`}
+      </details>
     `;
   }
 
   private onIdentifierInput(event: Event): void {
     this.identifier = (event.currentTarget as HTMLInputElement).value;
+  }
+
+  private onQueryInput(event: Event): void {
+    this.query = (event.currentTarget as HTMLInputElement).value;
+    this.syncUrl();
+  }
+
+  /**
+   * Mirrors the loaded item and the field filter into the URL, so the address bar
+   * is always a link to what's on screen. Blank values drop out of the query
+   * string rather than sitting there empty.
+   */
+  private syncUrl(): void {
+    const url = new URL(window.location.href);
+    const params: Record<string, string> = {
+      [IDENTIFIER_PARAM]: this.identifier,
+      [FILTER_PARAM]: this.query
+    };
+    for (const [name, value] of Object.entries(params)) {
+      if (value.trim()) url.searchParams.set(name, value.trim());
+      else url.searchParams.delete(name);
+    }
+    window.history.replaceState({}, '', url);
+  }
+
+  private onShowUnsetChange(event: Event): void {
+    this.showUnset = (event.currentTarget as HTMLInputElement).checked;
   }
 
   private onSubmit(event: Event): void {
@@ -351,6 +509,55 @@ export class AppRoot extends LitElement {
       color: #555;
       font-size: 0.85rem;
       margin-top: 0;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: flex-end;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin: 0.75rem 0;
+    }
+
+    .toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+      white-space: nowrap;
+    }
+
+    .toggle input {
+      width: auto;
+    }
+
+    tr.unset td {
+      color: #999;
+    }
+
+    .unmodeled {
+      margin-top: 1rem;
+    }
+
+    .unmodeled summary {
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: #555;
+    }
+
+    .keys {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+      margin: 0.5rem 0 0;
+    }
+
+    .keys code {
+      background: #f0f0f0;
+      border: 1px solid #ddd;
+      border-radius: 3px;
+      padding: 0.1rem 0.3rem;
+      font-size: 0.8rem;
     }
 
     table {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   base: './',
   root: resolve(__dirname, './demo'),
   build: {
+    // the demo labels each row with the class that parsed it, read off the
+    // constructor, so class names have to survive the build
+    minify: false,
     /**
      * This is the directory where the built files will be placed
      * that we upload to GitHub Pages.


### PR DESCRIPTION
## What

The demo table read from a hardcoded `FIELDS` list, so a field added to the model stayed invisible until someone remembered to add it here too. It now builds the rows from `Metadata`'s prototype getters, so every modeled field shows up on its own.

That's 95 fields, so there's a filter box above the table that takes one or more comma-separated terms (`aspect, tuner` narrows to both). Unset fields are hidden by default with a toggle to show them greyed out, and raw response keys the model never reads are listed under the table. Between those you can tell whether a field you can't find is a gap in the model or a gap in the demo, which is the question that came up on [WEBDEV-8641](https://webarchive.jira.com/browse/WEBDEV-8641) QA.

The loaded item and filter are kept in the URL (`?identifier=…&filter=…`), so you can link someone straight to a view. The filter param carries the canonical term list, so the link stays tidy however it was typed.

## How the unmodeled list works

Getter names don't always match raw keys (`access_restricted_item` reads `access-restricted-item`) and `mapField` lets one field fall back across several keys, so name matching can't tell you which keys are modeled. It hands `Metadata` a Proxy over the raw response, touches every field, and collects the keys that actually got read.

## Test plan

Full suite green (136/136), lint and tsc clean. Checked against the deployed preview in a browser:

- `gd73-06-10…` shows 22 of 95 modeled fields set, 19 unmodeled keys.
- Filter `date` gives `addeddate` / `date` / `publicdate`. With "Show unset" on it also lists `indexdate`, `reviewdate`, and `scandate` greyed out. Clearing the filter with unset shown gives all 95 rows.
- Filter `station, codec` gives `audio_codec` / `station_name` / `video_codec`, and the URL reads `filter=station,codec`. Typed messily as `  Station ,, codec,  ` it gives the same rows and the same URL.
- [`?identifier=KGO…&filter=aspect,tuner,scandate,utc`](https://internetarchive.github.io/iaux-item-metadata/pr/pr-59/?identifier=KGO_20101106_063500_Nightline&filter=aspect,tuner,scandate,utc) loads the item with the filter prefilled and shows the four structured values, including `scandate` as `2010-11-06T13:35:00.000Z`.
- The KGO item now has **no** unmodeled section at all, because [#49](https://github.com/internetarchive/iaux-item-metadata/pull/49) landed and every raw key on it is modeled.

That last point is what the change is for. The TV fields were never added to this demo by hand. They moved out of the unmodeled list and into the table on their own when `main` gained them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[WEBDEV-8641]: https://webarchive.jira.com/browse/WEBDEV-8641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ