### PR TITLE
WEBDEV-8924: Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ storybook-static
 logs
 *.log
 npm-debug.log*
+
+## git worktrees for feature branches
+/.claude/worktrees/


### PR DESCRIPTION
Feature work happens in a worktree under `.claude/worktrees/`, which showed up as untracked files in the primary checkout. Same entry petabox, offshoot and iaux-metadata-service have.

Scoped to that path rather than all of `.claude`, since other `.claude` contents can be worth tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GxnijHsZmBrHkcuJ5XYf9