### PR TITLE
WEBDEV-8923: Add MetadataFieldKey for Metadata's field names

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,3 +63,4 @@ export {
   MetadataFieldInterface,
   MetadataRawValue
 } from './src/models/metadata-fields/metadata-field';
+export type { MetadataFieldKey } from './src/models/metadata-field-key';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/iaux-item-metadata",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/iaux-item-metadata",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/field-parsers": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {

--- a/src/models/metadata-field-key.ts
+++ b/src/models/metadata-field-key.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from './metadata';
+import type { MetadataFieldInterface } from './metadata-fields/metadata-field';
+
+/**
+ * The names of `Metadata`'s fields, i.e. the members whose value is a
+ * `MetadataField`.
+ *
+ * Derived from `Metadata` rather than listed, so a field added there is
+ * available here with no matching change. Members that aren't fields are
+ * excluded, so `identifier` (a plain string) and `rawMetadata` (a plain
+ * record) are rejected.
+ *
+ * Useful for anything that takes a field name and wants the corresponding
+ * field type, since `Metadata[K]` then resolves to the field class:
+ *
+ * ```ts
+ * function read<K extends MetadataFieldKey>(m: Metadata, key: K): Metadata[K] {
+ *   return m[key];
+ * }
+ * read(metadata, 'collection'); // StringField | undefined
+ * read(metadata, 'addeddate'); // DateField | undefined
+ * ```
+ */
+export type MetadataFieldKey = {
+  [K in keyof Metadata]-?: NonNullable<
+    Metadata[K]
+  > extends MetadataFieldInterface<unknown>
+    ? K
+    : never;
+}[keyof Metadata];

--- a/test/models/metadata-field-key.test.ts
+++ b/test/models/metadata-field-key.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+import { Metadata } from '../../src/models/metadata';
+import type { MetadataFieldKey } from '../../src/models/metadata-field-key';
+
+/**
+ * The type has no runtime behaviour, so these are compile-time assertions that
+ * happen to run. Anything mistyped here fails `tsc`, which the test script runs
+ * ahead of the suite.
+ */
+describe('MetadataFieldKey', () => {
+  it('resolves a field name to its field type', () => {
+    const metadata = new Metadata({
+      collection: ['kodi_archive', 'community'],
+      addeddate: '2018-08-13 10:08:32',
+      mediatype: 'image'
+    });
+
+    function read<K extends MetadataFieldKey>(key: K): Metadata[K] {
+      return metadata[key];
+    }
+
+    // Each of these is typed as its own field class, not a union.
+    const collection: string | undefined = read('collection')?.value;
+    const added: Date | undefined = read('addeddate')?.value;
+    const mediatype: string | undefined = read('mediatype')?.value;
+
+    expect(collection).to.equal('kodi_archive');
+    expect(added).to.be.instanceOf(Date);
+    expect(mediatype).to.equal('image');
+  });
+
+  it('accepts every field name', () => {
+    const keys: MetadataFieldKey[] = [
+      'collection',
+      'addeddate',
+      'mediatype',
+      'title',
+      'item_size'
+    ];
+    expect(keys).to.have.length(5);
+  });
+
+  it('rejects members that are not fields', () => {
+    // identifier is a plain string and rawMetadata a plain record, so neither
+    // is a field name.
+    // @ts-expect-error identifier is not a MetadataField
+    const a: MetadataFieldKey = 'identifier';
+    // @ts-expect-error rawMetadata is not a MetadataField
+    const b: MetadataFieldKey = 'rawMetadata';
+    // @ts-expect-error not a member of Metadata at all
+    const c: MetadataFieldKey = 'not_a_real_field';
+    expect([a, b, c]).to.have.length(3);
+  });
+});


### PR DESCRIPTION
The names of `Metadata`'s members whose value is a `MetadataField`.

```ts
function read<K extends MetadataFieldKey>(m: Metadata, key: K): Metadata[K] {
  return m[key];
}
read(metadata, 'collection'); // StringField | undefined
read(metadata, 'addeddate');  // DateField | undefined
```

Derived from `Metadata` rather than listed, so a field added there is picked up with no matching change here. Members that aren't fields are excluded, so `identifier` (a plain string) and `rawMetadata` (a plain record) are rejected at compile time — there are `@ts-expect-error` assertions for each.

Written for metadata-service's `fetchMetadataField` ([WEBDEV-8920](https://webarchive.jira.com/browse/WEBDEV-8920)), which takes a field name and derives the field type from it. It describes `Metadata`'s shape, though, so it belongs next to `Metadata` rather than in the service. 8920 keeps its copy unexported and will import from here once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GxnijHsZmBrHkcuJ5XYf9

[WEBDEV-8920]: https://webarchive.jira.com/browse/WEBDEV-8920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ